### PR TITLE
Fix: Time/Spread crackling past noon: audio block size 7 → 16

### DIFF
--- a/TimeMachine.cpp
+++ b/TimeMachine.cpp
@@ -420,7 +420,7 @@ int main(void)
     hw.Init();
 	hw.StartLog();
 
-	hw.SetAudioBlockSize(7); // number of samples handled per callback
+	hw.SetAudioBlockSize(16); // number of samples handled per callback
 
 	dsy_gpio_pin gatePin = CLOCK;
 	gate.Init(&gatePin);


### PR DESCRIPTION
Block size 7 amortized fixed per-callback overhead (control reads,
slewer ticks, spreadTaps with pow() calls, biquad reconfigures) over
only 7 samples, pushing CPU close to 100% under cache-stressy conditions
(long delays scatter SDRAM reads across the 57 MB delay buffer). Audible
as sample-rate clicks past noon on Time and Spread, worst on Time which
scales the whole delay range.

Measured worst-case CPU with the firmware's existing cpuMeter at
Time max + Spread max + feedback off, sustained tonal input:

  block 7:  ~89% AVG / ~100%+ MAX  cracks (original)
  block 8:   84% / 95%             cracks
  block 10:  75% / 87%             clean
  block 12:  72% / 80%             clean
  block 16:  64% / 76%             clean (chosen)
  block 48:  52% / 57%             clean (Daisy default)

Block 16 sits comfortably below the audible cliff (~90% MAX) with ~24
points of CPU AVG headroom for future DSP additions. Latency cost vs
the original is 0.375 ms.

Verified audibly clean on Daisy Patch SM in Tiptop Mantis case with
sustained tonal input: full Time and Spread sweeps, varying feedback
levels, multiple tap-slider combinations, with and without CV
modulation on Spread.
